### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "http-errors": "~1.6.2",
     "jade": "~1.11.0",
     "lowdb": "^1.0.0",
-    "morgan": "~1.9.0",
-    "npm": "^5.8.0"
+    "morgan": "~1.9.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",


### PR DESCRIPTION

Hello devopssiri!

It seems like you have npm as one of your (dev-) dependency in docker-project.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
